### PR TITLE
Add GH Actions for CI and Publish to Pub.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Courier CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+ test:
+    name: Build and Run Unit Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+    - run: cd courier_dart_sdk && flutter test --coverage

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish GH Pages
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish to Pub.dev
+
+on:
+  push:
+    tags: 
+      - '*'   
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+        
+      - name: '>> Dart package <<'
+        uses: k-paxian/dart-package-publisher@master
+        with:
+          credentialJson: ${{ secrets.CREDENTIAL_JSON }}
+          relativePath: courier_dart_sdk
+          dryRunOnly: true # set to false for real publishing later


### PR DESCRIPTION
This MR contains:
- Added Job for Publishing to Pub.Dev using https://github.com/marketplace/actions/publish-dart-flutter-package
- Added Job to to Unit Test using https://github.com/marketplace/actions/flutter-action
- Refactor directory name for Publish to GH Pages