### PR TITLE
Add try catch when logging handle message using UTF-8 decode

### DIFF
--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -216,7 +216,12 @@ class _CourierClientImpl implements CourierClient {
     Uint8List bytes = (arguments)["message"] as Uint8List;
     String topic = (arguments)["topic"] as String;
 
-    log('Message receive: ${utf8.decode(bytes)} on topic: $topic');
+    try {
+      log('Message receive: ${utf8.decode(bytes)} on topic: $topic');
+    } on Exception catch (e) {
+      log('Message receive: failed to decode using utf 8');
+    }
+
     messageStreamController
         .add(CourierMessage(bytes: bytes, topic: topic, qos: QoS.zero));
   }


### PR DESCRIPTION
The handleMessage method throws an exception when the bytes format is not string (e.g protobuf, etc). In this case, i added try catch so new data can still be published to `messageStreamController`