### PR TITLE
Add no-op mqttchuck to android gradle build for production build task

### DIFF
--- a/courier_dart_sdk/android/build.gradle
+++ b/courier_dart_sdk/android/build.gradle
@@ -54,5 +54,17 @@ dependencies {
     implementation "com.gojek.courier:mqtt-client:$courier_version"
     implementation "com.gojek.courier:timer-pingsender:$courier_version"
     implementation "com.gojek.courier:alarm-pingsender:$courier_version"
-    implementation "com.gojek.courier:chuck-mqtt:$courier_version"
+    
+    def is_production_flavor = false
+    gradle.startParameter.getTaskNames().each { task -> 
+        if (task.toLowerCase().contains("production")) {
+            is_production_flavor = true 
+        } 
+    }
+
+    if (is_production_flavor) {
+        implementation "com.gojek.courier:chuck-mqtt-no-ops:$courier_version"
+    } else {
+        implementation "com.gojek.courier:chuck-mqtt:$courier_version"
+    }
 }


### PR DESCRIPTION
This MR add the options for android to optionally depends on `no-op` MQTTChuck gradle dependency. This will reduce apk size by almost 1 MB. In case `production` string exist in gradle task, it will use MQTTChuck `no-op`. This is useful on production environment as we don't need have MQTT Chuck shown to customers.