### PR TITLE
Pass scheme from arguments method channel to iOS connectOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ import 'package:courier_dart_sdk/courier_client.dart';
 
 Add the following snippet to Podfile in your project's iOS folder:
 ```shell
-      pod 'CourierCore', '0.0.17', :modular_headers => true
-      pod 'CourierMQTT', '0.0.17', :modular_headers => true
+      pod 'CourierCore', '0.0.19', :modular_headers => true
+      pod 'CourierMQTT', '0.0.19', :modular_headers => true
 ```
 
 ### Create CourierClient

--- a/courier_dart_sdk/ios/Classes/SwiftCourierDartSdkPlugin.swift
+++ b/courier_dart_sdk/ios/Classes/SwiftCourierDartSdkPlugin.swift
@@ -90,7 +90,8 @@ public class SwiftCourierDartSdkPlugin: NSObject, FlutterPlugin {
             clientId: arguments["clientId"] as! String,
             username: arguments["username"] as! String,
             password: arguments["password"] as! String,
-            isCleanSession: arguments["cleanSession"] as! Bool
+            isCleanSession: arguments["cleanSession"] as! Bool,
+            scheme: arguments["scheme"] as? String
         )
         self.courierClientDelegate.connect(connectOptions)
     }

--- a/courier_dart_sdk/ios/courier_dart_sdk.podspec
+++ b/courier_dart_sdk/ios/courier_dart_sdk.podspec
@@ -15,9 +15,9 @@ Flutter SDK for Courier
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'CourierCore', '0.0.17'
-  s.dependency 'CourierMQTT', '0.0.17'
-  s.dependency 'CourierMQTTChuck', '0.0.17'
+  s.dependency 'CourierCore', '0.0.19'
+  s.dependency 'CourierMQTT', '0.0.19'
+  s.dependency 'CourierMQTTChuck', '0.0.19'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/courier_dart_sdk_demo/ios/Podfile
+++ b/courier_dart_sdk_demo/ios/Podfile
@@ -29,9 +29,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-  pod 'CourierCore', '0.0.17', :modular_headers => true
-  pod 'CourierMQTT', '0.0.17', :modular_headers => true
-  pod 'CourierMQTTChuck', '0.0.17', :modular_headers => true
+  pod 'CourierCore', '0.0.19', :modular_headers => true
+  pod 'CourierMQTT', '0.0.19', :modular_headers => true
+  pod 'CourierMQTTChuck', '0.0.19', :modular_headers => true
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/courier_dart_sdk_demo/ios/Podfile.lock
+++ b/courier_dart_sdk_demo/ios/Podfile.lock
@@ -1,29 +1,29 @@
 PODS:
   - courier_dart_sdk (0.0.1):
-    - CourierCore (= 0.0.17)
-    - CourierMQTT (= 0.0.17)
-    - CourierMQTTChuck (= 0.0.17)
+    - CourierCore (= 0.0.19)
+    - CourierMQTT (= 0.0.19)
+    - CourierMQTTChuck (= 0.0.19)
     - Flutter
-  - CourierCore (0.0.17)
-  - CourierMQTT (0.0.17):
-    - CourierCore (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
+  - CourierCore (0.0.19)
+  - CourierMQTT (0.0.19):
+    - CourierCore (= 0.0.19)
+    - MQTTClientGJ (= 0.0.19)
     - ReachabilitySwift (= 5.0.0)
-  - CourierMQTTChuck (0.0.17):
-    - CourierCore (= 0.0.17)
-    - CourierMQTT (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
+  - CourierMQTTChuck (0.0.19):
+    - CourierCore (= 0.0.19)
+    - CourierMQTT (= 0.0.19)
+    - MQTTClientGJ (= 0.0.19)
   - Flutter (1.0.0)
-  - MQTTClientGJ (0.0.17)
+  - MQTTClientGJ (0.0.19)
   - permission_handler_apple (9.0.4):
     - Flutter
   - ReachabilitySwift (5.0.0)
 
 DEPENDENCIES:
   - courier_dart_sdk (from `.symlinks/plugins/courier_dart_sdk/ios`)
-  - CourierCore (= 0.0.17)
-  - CourierMQTT (= 0.0.17)
-  - CourierMQTTChuck (= 0.0.17)
+  - CourierCore (= 0.0.19)
+  - CourierMQTT (= 0.0.19)
+  - CourierMQTTChuck (= 0.0.19)
   - Flutter (from `Flutter`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
@@ -44,15 +44,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
-  courier_dart_sdk: d6a793b0a344d201c9c0067cfdd266eab3015d60
-  CourierCore: 5561c7ff8fdd9b722bedf06a290be2f7e9242f80
-  CourierMQTT: 40ca2bde67a0a5c9c222c3e972861b34611907b8
-  CourierMQTTChuck: 970cd9893626cea84b0ebbd2db55533d356c7258
+  courier_dart_sdk: 2a0bb812b345a9267495b31e0f83452656d9c882
+  CourierCore: bdaf367323ba99e3b369ad4b9c449a2acb235fbe
+  CourierMQTT: bcfb8a4c51d8b144d36bd5c17f1750ce81af8a1b
+  CourierMQTTChuck: 945a4daf14fb6a421d8afdcdf4d854fd3f69fa1b
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  MQTTClientGJ: 2da01c1669f12cab46e2ddb0eb26e8b4cf54fe9c
+  MQTTClientGJ: a3840bdac554c11913a8bd65ea09657651786742
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
 
-PODFILE CHECKSUM: 7823e7dbc8d68e98861310540a3c95fc601af27e
+PODFILE CHECKSUM: e89a4056917fe634c35d24da7e0ac86bf7c6fdda
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/courier_dart_sdk_demo/ios/Pods/CourierCore/CourierCore/Models/ConnectOptions.swift
+++ b/courier_dart_sdk_demo/ios/Pods/CourierCore/CourierCore/Models/ConnectOptions.swift
@@ -19,6 +19,8 @@ public struct ConnectOptions: Equatable {
     public let userProperties: [String: String]?
     
     public let alpn: [String]?
+    
+    public let scheme: String?
 
     public init(
         host: String,
@@ -29,7 +31,8 @@ public struct ConnectOptions: Equatable {
         password: String,
         isCleanSession: Bool = false,
         userProperties: [String: String]? = nil,
-        alpn: [String]? = nil
+        alpn: [String]? = nil,
+        scheme: String? = nil
     ) {
         self.host = host
         self.port = port
@@ -40,5 +43,10 @@ public struct ConnectOptions: Equatable {
         self.isCleanSession = isCleanSession
         self.userProperties = userProperties
         self.alpn = alpn
+        self.scheme = scheme
+    }
+    
+    public var shouldUseSecureTransportLayer: Bool {
+        scheme == "ssl" || scheme == "tls" || port == 443
     }
 }

--- a/courier_dart_sdk_demo/ios/Pods/CourierCore/CourierCore/Models/QoS.swift
+++ b/courier_dart_sdk_demo/ios/Pods/CourierCore/CourierCore/Models/QoS.swift
@@ -1,10 +1,51 @@
 import Foundation
 
 public enum QoS: Int {
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case zero = 0
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case one = 1
-
+    
+    // http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718100
     case two = 2
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
+    case oneWithoutPersistenceAndNoRetry = 3
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
+    case oneWithoutPersistenceAndRetry = 4
+    
+    public var rawValue: Int {
+        switch self {
+        case .zero:
+            return 0
+        case .one, .oneWithoutPersistenceAndNoRetry, .oneWithoutPersistenceAndRetry:
+            return 1
+        case .two:
+            return 2
+        }
+    }
+    
+    public var type: Int {
+        switch self {
+        case .zero:
+            return 0
+        case .one:
+            return 1
+        case .two:
+            return 2
+        case .oneWithoutPersistenceAndNoRetry:
+            return 3
+        case .oneWithoutPersistenceAndRetry:
+            return 4
+        }
+    }
 }

--- a/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
+++ b/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkConnection.swift
@@ -73,7 +73,8 @@ class MQTTClientFrameworkConnection: NSObject, IMQTTConnection {
 
         let port = Int(connectOptions.port)
         var securityPolicy: MQTTSSLSecurityPolicy?
-        if port == 443 {
+        
+        if connectOptions.shouldUseSecureTransportLayer {
             securityPolicy = MQTTSSLSecurityPolicy()
             securityPolicy?.allowInvalidCertificates = true
         }

--- a/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
+++ b/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrameworkSessionManager.swift
@@ -144,7 +144,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         printDebug("MQTT - COURIER: Client Session Manager connect to: \(host)")
         self.connectOptions = connectOptions
         let shouldReconnect = self.session != nil
-        let isTls = port == 443
+        let isTls = connectOptions.shouldUseSecureTransportLayer
 
         if (self.session == nil || host != self.host) ||
             port != self.port ?? 0 ||
@@ -297,7 +297,7 @@ class MQTTClientFrameworkSessionManager: NSObject, IMQTTClientFrameworkSessionMa
         topics.forEach { topic, qos in
             let attemptTimestamp = Date()
             self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeAttempt(topics: [topic])))
-            session?.subscribe(toTopics: [topic: NSNumber(value: qos.rawValue)], subscribeHandler: { [weak self] (error, responseCodes) in
+            session?.subscribe(toTopics: [topic: NSNumber(value: qos.type)], subscribeHandler: { [weak self] (error, responseCodes) in
                 guard let self = self else { return }
                 if let error = error {
                     self.eventHandler.onEvent(.init(connectionInfo: connectOptions, event: .subscribeFailure(topics: [(topic, qos)], timeTaken: attemptTimestamp.timeTaken, error: error)))

--- a/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrramework+Extension.swift
+++ b/courier_dart_sdk_demo/ios/Pods/CourierMQTT/CourierMQTT/MQTT/Connection/MQTT-Client-Framework/MQTTClientFrramework+Extension.swift
@@ -41,6 +41,6 @@ extension MQTTCommandType {
 
 extension MQTTQosLevel {
     init(qos: QoS) {
-        self = MQTTQosLevel(rawValue: UInt8(qos.rawValue)) ?? .atMostOnce
+        self = MQTTQosLevel(rawValue: UInt8(qos.type)) ?? .atMostOnce
     }
 }

--- a/courier_dart_sdk_demo/ios/Pods/Local Podspecs/courier_dart_sdk.podspec.json
+++ b/courier_dart_sdk_demo/ios/Pods/Local Podspecs/courier_dart_sdk.podspec.json
@@ -19,13 +19,13 @@
 
     ],
     "CourierCore": [
-      "0.0.17"
+      "0.0.19"
     ],
     "CourierMQTT": [
-      "0.0.17"
+      "0.0.19"
     ],
     "CourierMQTTChuck": [
-      "0.0.17"
+      "0.0.19"
     ]
   },
   "platforms": {

--- a/courier_dart_sdk_demo/ios/Pods/MQTTClientGJ/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.h
+++ b/courier_dart_sdk_demo/ios/Pods/MQTTClientGJ/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTMessage.h
@@ -12,7 +12,18 @@
 typedef NS_ENUM(UInt8, MQTTQosLevel) {
     MQTTQosLevelAtMostOnce = 0,
     MQTTQosLevelAtLeastOnce = 1,
-    MQTTQosLevelExactlyOnce = 2
+    MQTTQosLevelExactlyOnce = 2,
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+       nor persisted and neither retied at send after one attempt.
+       The message arrives at the receiver either once or not at all.
+        Your broker need to be configured to support this **/
+    MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry = 3,
+    
+    /** Like QoS1, Message delivery is acknowledged with Puback, but unlike Qos1 messages are
+         not persisted. The messages are retried within active connection if delivery is not acknowledged.
+        Your broker need to be configured to support this **/
+    MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry = 4
 };
 
 /**

--- a/courier_dart_sdk_demo/ios/Pods/MQTTClientGJ/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
+++ b/courier_dart_sdk_demo/ios/Pods/MQTTClientGJ/Internal/MQTT-Client-Framework/MQTTClientGJ/MQTTClientGJ/MQTTSession.m
@@ -251,10 +251,13 @@ NSString * const MQTTClientcourier = @"GJ";
         if (MQTTStrict.strict &&
             qos.intValue != MQTTQosLevelAtMostOnce &&
             qos.intValue != MQTTQosLevelAtLeastOnce &&
-            qos.intValue != MQTTQosLevelExactlyOnce) {
+            qos.intValue != MQTTQosLevelExactlyOnce &&
+            qos.intValue != MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry &&
+            qos.intValue != MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+        ) {
             NSException* myException = [NSException
                                         exceptionWithName:@"Illegal QoS level"
-                                        reason:[NSString stringWithFormat:@"%d is not 0, 1, or 2", qos.intValue]
+                                        reason:[NSString stringWithFormat:@"%d is not 0, 1, 2, 3, or 4", qos.intValue]
                                         userInfo:nil];
             @throw myException;
         }
@@ -378,16 +381,27 @@ NSString * const MQTTClientcourier = @"GJ";
     if (MQTTStrict.strict &&
         qos != MQTTQosLevelAtMostOnce &&
         qos != MQTTQosLevelAtLeastOnce &&
-        qos != MQTTQosLevelExactlyOnce) {
+        qos != MQTTQosLevelExactlyOnce &&
+        qos != MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry &&
+        qos != MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+        ) {
         NSException* myException = [NSException
                                     exceptionWithName:@"Illegal QoS level"
-                                    reason:[NSString stringWithFormat:@"%d is not 0, 1, or 2", qos]
+                                    reason:[NSString stringWithFormat:@"%d is not 0, 1, 2, 3, or 4", qos]
                                     userInfo:nil];
         @throw myException;
     }
 
     UInt16 msgId = 0;
-    if (!qos) {
+    if (!qos ||
+        qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry ||
+        qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry
+    ) {
+        // Set these *special QoSes* as QoS One
+        if (qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry || qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndNoRetry) {
+            qos = MQTTQosLevelAtLeastOnce;
+            msgId = [self nextMsgId];
+        }
         MQTTMessage *msg = [MQTTMessage publishMessageWithData:data
                                                        onTopic:topic
                                                            qos:qos
@@ -1400,7 +1414,10 @@ NSString * const MQTTClientcourier = @"GJ";
     if (self.shouldEnableActivityCheckTimeout) {
         switch (message.type) {
             case MQTTPublish:
-                if (message.qos == MQTTQosLevelAtMostOnce) return;
+                if (message.qos == MQTTQosLevelAtMostOnce ||
+                    message.qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry ||
+                    message.qos == MQTTQosLevelAtLeastOnceWithoutPersistenceAndRetry
+                ) return;
                 [self checkAndSetFastReconnectTimestamp];
                 return;
             

--- a/courier_dart_sdk_demo/ios/Pods/Manifest.lock
+++ b/courier_dart_sdk_demo/ios/Pods/Manifest.lock
@@ -1,29 +1,29 @@
 PODS:
   - courier_dart_sdk (0.0.1):
-    - CourierCore (= 0.0.17)
-    - CourierMQTT (= 0.0.17)
-    - CourierMQTTChuck (= 0.0.17)
+    - CourierCore (= 0.0.19)
+    - CourierMQTT (= 0.0.19)
+    - CourierMQTTChuck (= 0.0.19)
     - Flutter
-  - CourierCore (0.0.17)
-  - CourierMQTT (0.0.17):
-    - CourierCore (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
+  - CourierCore (0.0.19)
+  - CourierMQTT (0.0.19):
+    - CourierCore (= 0.0.19)
+    - MQTTClientGJ (= 0.0.19)
     - ReachabilitySwift (= 5.0.0)
-  - CourierMQTTChuck (0.0.17):
-    - CourierCore (= 0.0.17)
-    - CourierMQTT (= 0.0.17)
-    - MQTTClientGJ (= 0.0.17)
+  - CourierMQTTChuck (0.0.19):
+    - CourierCore (= 0.0.19)
+    - CourierMQTT (= 0.0.19)
+    - MQTTClientGJ (= 0.0.19)
   - Flutter (1.0.0)
-  - MQTTClientGJ (0.0.17)
+  - MQTTClientGJ (0.0.19)
   - permission_handler_apple (9.0.4):
     - Flutter
   - ReachabilitySwift (5.0.0)
 
 DEPENDENCIES:
   - courier_dart_sdk (from `.symlinks/plugins/courier_dart_sdk/ios`)
-  - CourierCore (= 0.0.17)
-  - CourierMQTT (= 0.0.17)
-  - CourierMQTTChuck (= 0.0.17)
+  - CourierCore (= 0.0.19)
+  - CourierMQTT (= 0.0.19)
+  - CourierMQTTChuck (= 0.0.19)
   - Flutter (from `Flutter`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
@@ -44,15 +44,15 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
-  courier_dart_sdk: d6a793b0a344d201c9c0067cfdd266eab3015d60
-  CourierCore: 5561c7ff8fdd9b722bedf06a290be2f7e9242f80
-  CourierMQTT: 40ca2bde67a0a5c9c222c3e972861b34611907b8
-  CourierMQTTChuck: 970cd9893626cea84b0ebbd2db55533d356c7258
+  courier_dart_sdk: 2a0bb812b345a9267495b31e0f83452656d9c882
+  CourierCore: bdaf367323ba99e3b369ad4b9c449a2acb235fbe
+  CourierMQTT: bcfb8a4c51d8b144d36bd5c17f1750ce81af8a1b
+  CourierMQTTChuck: 945a4daf14fb6a421d8afdcdf4d854fd3f69fa1b
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  MQTTClientGJ: 2da01c1669f12cab46e2ddb0eb26e8b4cf54fe9c
+  MQTTClientGJ: a3840bdac554c11913a8bd65ea09657651786742
   permission_handler_apple: 44366e37eaf29454a1e7b1b7d736c2cceaeb17ce
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
 
-PODFILE CHECKSUM: 7823e7dbc8d68e98861310540a3c95fc601af27e
+PODFILE CHECKSUM: e89a4056917fe634c35d24da7e0ac86bf7c6fdda
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/courier_dart_sdk_demo/ios/Pods/Pods.xcodeproj/project.pbxproj
+++ b/courier_dart_sdk_demo/ios/Pods/Pods.xcodeproj/project.pbxproj
@@ -2409,41 +2409,6 @@
 			};
 			name = Debug;
 		};
-		1E6C34E88528B1F4B2516FF5E55EAFDA /* Profile */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2DAEA285D632B0182B2F1AAFCBDFDAE6 /* MQTTClientGJ.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
-				PRODUCT_MODULE_NAME = MQTTClientGJ;
-				PRODUCT_NAME = MQTTClientGJ;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Profile;
-		};
 		2722B9F1CFDADD252613E01BE5908300 /* Profile */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8666DF732269BAA1FD29C8AF6E510D2F /* CourierMQTT.release.xcconfig */;
@@ -2603,6 +2568,42 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		8E58DB6CA0C60B828A422EDC259A082B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B909233D7A36DB66E2DB886CBD5FDB66 /* MQTTClientGJ.debug.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_MODULE_NAME = MQTTClientGJ;
+				PRODUCT_NAME = MQTTClientGJ;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		903A0004D3E6651EFD5D2E16214D101B /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2843,41 +2844,6 @@
 				ONLY_ACTIVE_ARCH = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		B1D898AD6BA7C80D18A2C24582BE8441 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B909233D7A36DB66E2DB886CBD5FDB66 /* MQTTClientGJ.debug.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
-				ONLY_ACTIVE_ARCH = NO;
-				PRODUCT_MODULE_NAME = MQTTClientGJ;
-				PRODUCT_NAME = MQTTClientGJ;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
 		};
@@ -3419,6 +3385,42 @@
 			};
 			name = Release;
 		};
+		E39BF582915886649218E4E6C3BA42D3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2DAEA285D632B0182B2F1AAFCBDFDAE6 /* MQTTClientGJ.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
+				PRODUCT_MODULE_NAME = MQTTClientGJ;
+				PRODUCT_NAME = MQTTClientGJ;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		EC6483B03A894AE7AD8DA79230516D91 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D2FA70CA298C392CB8332ADEEDD1CE85 /* Pods-Runner.release.xcconfig */;
@@ -3545,41 +3547,6 @@
 			};
 			name = Profile;
 		};
-		F5F1079798CB7504E433A341897C558C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2DAEA285D632B0182B2F1AAFCBDFDAE6 /* MQTTClientGJ.release.xcconfig */;
-			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
-				PRODUCT_MODULE_NAME = MQTTClientGJ;
-				PRODUCT_NAME = MQTTClientGJ;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		F6E1129A9BCFEA87CD2E974BBECE2127 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DE356B25EF241ACF0745B4C8FC2CFE7F /* CourierCore.debug.xcconfig */;
@@ -3615,6 +3582,42 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		FFB80329A65C24B900D87B6C0A7B6035 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2DAEA285D632B0182B2F1AAFCBDFDAE6 /* MQTTClientGJ.release.xcconfig */;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/MQTTClientGJ/MQTTClientGJ-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MODULEMAP_FILE = "Target Support Files/MQTTClientGJ/MQTTClientGJ.modulemap";
+				PRODUCT_MODULE_NAME = MQTTClientGJ;
+				PRODUCT_NAME = MQTTClientGJ;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Profile;
 		};
 /* End XCBuildConfiguration section */
 
@@ -3692,9 +3695,9 @@
 		AD841D02A27AA266778B27281D7305A1 /* Build configuration list for PBXNativeTarget "MQTTClientGJ" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B1D898AD6BA7C80D18A2C24582BE8441 /* Debug */,
-				1E6C34E88528B1F4B2516FF5E55EAFDA /* Profile */,
-				F5F1079798CB7504E433A341897C558C /* Release */,
+				8E58DB6CA0C60B828A422EDC259A082B /* Debug */,
+				FFB80329A65C24B900D87B6C0A7B6035 /* Profile */,
+				E39BF582915886649218E4E6C3BA42D3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierCore/CourierCore-Info.plist
+++ b/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierCore/CourierCore-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.0.17</string>
+  <string>0.0.19</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierMQTT/CourierMQTT-Info.plist
+++ b/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierMQTT/CourierMQTT-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.0.17</string>
+  <string>0.0.19</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierMQTTChuck/CourierMQTTChuck-Info.plist
+++ b/courier_dart_sdk_demo/ios/Pods/Target Support Files/CourierMQTTChuck/CourierMQTTChuck-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.0.17</string>
+  <string>0.0.19</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/courier_dart_sdk_demo/ios/Pods/Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist
+++ b/courier_dart_sdk_demo/ios/Pods/Target Support Files/MQTTClientGJ/MQTTClientGJ-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.0.17</string>
+  <string>0.0.19</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/courier_dart_sdk_demo/ios/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh
+++ b/courier_dart_sdk_demo/ios/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh
@@ -41,7 +41,7 @@ install_framework()
 
   if [ -L "${source}" ]; then
     echo "Symlinked..."
-    source="$(readlink "${source}")"
+    source="$(readlink -f "${source}")"
   fi
 
   if [ -d "${source}/${BCSYMBOLMAP_DIR}" ]; then

--- a/docs/docs/Installation.md
+++ b/docs/docs/Installation.md
@@ -31,6 +31,6 @@ import 'package:courier_dart_sdk/courier_client.dart';
 
 Add the following snippet to Podfile in your project's iOS folder:
 ```shell
-      pod 'CourierCore', '0.0.17', :modular_headers => true
-      pod 'CourierMqtt', '0.0.17', :modular_headers => true
+      pod 'CourierCore', '0.0.19', :modular_headers => true
+      pod 'CourierMqtt', '0.0.19', :modular_headers => true
 ```


### PR DESCRIPTION
The Courier iOS sdk `0.0.19` has provided options to pass `scheme` to `ConnectOptions` to determine whether to use SSL/TLS transport security instead of just using port 443 . This MR provides implementation to pass the scheme to Courier iOS SDK ConnectOptions.