### PR TITLE
Add message adapter

### DIFF
--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -9,6 +9,7 @@ import 'package:courier_dart_sdk/courier_connect_options.dart';
 import 'package:courier_dart_sdk/courier_message.dart';
 import 'package:courier_dart_sdk/event/courier_event.dart';
 import 'package:courier_dart_sdk/event/courier_event_handler.dart';
+import 'package:courier_dart_sdk/message_adapter/json_message_adapter.dart';
 import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/services.dart';
@@ -26,7 +27,9 @@ abstract class CourierClient {
   static CourierClient create(
       {required AuthProvider authProvider,
       required CourierConfiguration config,
-      required List<MessageAdapter> messageAdapters}) {
+      List<MessageAdapter> messageAdapters = const <MessageAdapter>[
+        JSONMessageAdapter()
+      ]}) {
     return _CourierClientImpl(authProvider, config, messageAdapters);
   }
 }

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -110,6 +110,7 @@ class _CourierClientImpl implements CourierClient {
             log(error.toString());
           }
         }
+        return decoder(event.bytes);
       }
       throw "Data Type Not Supported";
     });

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
+import 'dart:typed_data';
 
 import 'package:courier_dart_sdk/auth/auth_provider.dart';
 import 'package:courier_dart_sdk/config/courier_configuration.dart';

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -23,7 +23,7 @@ abstract class CourierClient {
   void subscribe(String topic, QoS qos);
   void unsubscribe(String topic);
   Stream<T> courierMessageStream<T>(String topic, {dynamic decoder});
-  Stream<Uint8List> courierBytesStream<T>(String topic);
+  Stream<Uint8List> courierBytesStream(String topic);
 
   void publishCourierMessage(CourierMessage message, {dynamic encoder});
   Stream<CourierEvent> courierEventStream();
@@ -121,7 +121,7 @@ class _CourierClientImpl implements CourierClient {
   }
 
   @override
-  Stream<Uint8List> courierBytesStream<T>(String topic) =>
+  Stream<Uint8List> courierBytesStream(String topic) =>
       courierMessageStream<Uint8List>(topic);
 
   @override

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -111,7 +111,7 @@ class _CourierClientImpl implements CourierClient {
           }
         }
       }
-      throw "Date Type Not Supported";
+      throw "Data Type Not Supported";
     });
   }
 

--- a/courier_dart_sdk/lib/courier_message.dart
+++ b/courier_dart_sdk/lib/courier_message.dart
@@ -1,28 +1,17 @@
-import 'dart:typed_data';
-
 class CourierMessage {
-  final Uint8List bytes;
+  final Object payload;
   final String topic;
   final QoS qos;
 
-  CourierMessage({required this.bytes, required this.topic, required this.qos});
-
-  Map<String, Object> convertToMap() {
-    return {
-      "message": bytes,
-      "topic": topic,
-      "qos": qos.value
-    };
-  }
+  CourierMessage(
+      {required this.payload, required this.topic, required this.qos});
 }
 
-enum QoS {
-  zero, one, two
-}
+enum QoS { zero, one, two }
 
 extension QoSExtension on QoS {
   int get value {
-    switch(this) {
+    switch (this) {
       case QoS.zero:
         return 0;
       case QoS.one:

--- a/courier_dart_sdk/lib/message_adapter/bytes_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/bytes_message_adapter.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
+
+class BytesMessageAdapter extends MessageAdapter {
+  const BytesMessageAdapter();
+
+  @override
+  String contentType() => "application/octet-stream";
+
+  @override
+  T decode<T>(Uint8List bytes, dynamic decoder) {
+    if (T is Uint8List) {
+      return bytes as T;
+    }
+    T item = decoder(bytes);
+    return item;
+  }
+
+  @override
+  Uint8List encode(Object object, String topic, dynamic encoder) {
+    if (object is Uint8List) {
+      return object;
+    }
+    return encoder(object);
+  }
+}

--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
 
 class JSONMessageAdapter extends MessageAdapter {
+  const JSONMessageAdapter();
+
   @override
   String contentType() {
     return "application/json";
@@ -23,9 +25,4 @@ class JSONMessageAdapter extends MessageAdapter {
     final Uint8List byteArray = Uint8List.fromList(codeUnits);
     return byteArray;
   }
-}
-
-void x(int x, dynamic y) {}
-void main() {
-  x(5);
 }

--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -7,9 +7,7 @@ class JSONMessageAdapter extends MessageAdapter {
   const JSONMessageAdapter();
 
   @override
-  String contentType() {
-    return "application/json";
-  }
+  String contentType() => "application/json";
 
   @override
   T decode<T>(Uint8List bytes, dynamic decoder) {
@@ -19,7 +17,10 @@ class JSONMessageAdapter extends MessageAdapter {
   }
 
   @override
-  Uint8List encode(Object object, String topic) {
+  Uint8List encode(Object object, String topic, dynamic encoder) {
+    if (encoder != null) {
+      return encoder(object);
+    }
     final json = jsonEncode(object);
     final List<int> codeUnits = json.codeUnits;
     final Uint8List bytes = Uint8List.fromList(codeUnits);

--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
+
+class JSONMessageAdapter extends MessageAdapter {
+  @override
+  String contentType() {
+    return "application/json";
+  }
+
+  @override
+  T decode<T>(Uint8List bytes, dynamic decoder) {
+    final json = jsonDecode(String.fromCharCodes(bytes));
+    T item = decoder(json);
+    return item;
+  }
+
+  @override
+  Uint8List encode(Object object, String topic) {
+    final json = jsonEncode(object);
+    final List<int> codeUnits = json.codeUnits;
+    final Uint8List byteArray = Uint8List.fromList(codeUnits);
+    return byteArray;
+  }
+}

--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -22,7 +22,7 @@ class JSONMessageAdapter extends MessageAdapter {
   Uint8List encode(Object object, String topic) {
     final json = jsonEncode(object);
     final List<int> codeUnits = json.codeUnits;
-    final Uint8List byteArray = Uint8List.fromList(codeUnits);
-    return byteArray;
+    final Uint8List bytes = Uint8List.fromList(codeUnits);
+    return bytes;
   }
 }

--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -24,3 +24,8 @@ class JSONMessageAdapter extends MessageAdapter {
     return byteArray;
   }
 }
+
+void x(int x, dynamic y) {}
+void main() {
+  x(5);
+}

--- a/courier_dart_sdk/lib/message_adapter/message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/message_adapter.dart
@@ -25,5 +25,5 @@ abstract class MessageAdapter {
   /// final person = Person(name: "john");
   /// final bytes = messageAdapter.encode(person);
   /// ```
-  Uint8List encode(Object object, String topic);
+  Uint8List encode(Object object, String topic, dynamic encoder);
 }

--- a/courier_dart_sdk/lib/message_adapter/message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/message_adapter.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+/// This class decode bytes to object and encode object to bytes
+abstract class MessageAdapter {
+  /// Content Type (e.g application/json, etc)
+  String contentType();
+
+  /// Decode bytes to generic typed object.
+  ///
+  /// You need to pass `constructor tearoffs` for your type in [decoder] parameter.
+  /// https://github.com/dart-lang/language/blob/main/accepted/2.15/constructor-tearoffs/feature-specification.md
+  ///
+  /// Example of using fromJson that accepts Map to constuct `Person` instance:
+  /// ```dart
+  /// Person personFromBytes = jsonMessageAdapter.decode(bytes, Person.fromJson);
+  /// ```
+  T decode<T>(Uint8List bytes, dynamic decoder);
+
+  /// Encode object to bytes.
+  ///
+  /// Example:
+  /// ```dart
+  /// final person = Person(name: "john");
+  /// final bytes = messageAdapter.encode(person);
+  /// ```
+  Uint8List encode(Object object, String topic);
+}

--- a/courier_dart_sdk/lib/message_adapter/message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/message_adapter.dart
@@ -2,6 +2,8 @@ import 'dart:typed_data';
 
 /// This class decode bytes to object and encode object to bytes
 abstract class MessageAdapter {
+  const MessageAdapter();
+
   /// Content Type (e.g application/json, etc)
   String contentType();
 

--- a/courier_dart_sdk/lib/message_adapter/string_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/string_message_adapter.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
+
+class StringMessageAdapter extends MessageAdapter {
+  const StringMessageAdapter();
+
+  @override
+  String contentType() => "text/plain";
+
+  @override
+  T decode<T>(Uint8List bytes, dynamic decoder) {
+    String text = utf8.decode(bytes);
+    return text as T;
+  }
+
+  @override
+  Uint8List encode(Object object, String topic, dynamic encoder) {
+    if (object is String) {
+      List<int> bytes = utf8.encode(object);
+      return Uint8List.fromList(bytes);
+    }
+    return encoder(object);
+  }
+}

--- a/courier_dart_sdk/test/courier_sdk_test.dart
+++ b/courier_dart_sdk/test/courier_sdk_test.dart
@@ -10,8 +10,9 @@ void main() {
     String topic = "test-topic";
     QoS qos = QoS.zero;
 
-    CourierMessage courierMessage = CourierMessage(bytes: bytes, topic: topic, qos: qos);
-    expect(courierMessage.convertToMap()["topic"], "test-topic");
-    expect(courierMessage.convertToMap()["qos"], 0);
+    CourierMessage courierMessage =
+        CourierMessage(payload: bytes, topic: topic, qos: qos);
+    expect(courierMessage.topic, "test-topic");
+    expect(courierMessage.qos, 0);
   });
 }

--- a/courier_dart_sdk/test/courier_sdk_test.dart
+++ b/courier_dart_sdk/test/courier_sdk_test.dart
@@ -13,6 +13,6 @@ void main() {
     CourierMessage courierMessage =
         CourierMessage(payload: bytes, topic: topic, qos: qos);
     expect(courierMessage.topic, "test-topic");
-    expect(courierMessage.qos, 0);
+    expect(courierMessage.qos.value, 0);
   });
 }

--- a/courier_dart_sdk_demo/lib/main.dart
+++ b/courier_dart_sdk_demo/lib/main.dart
@@ -98,10 +98,19 @@ class MyHomePage extends StatelessWidget {
         "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update/foreground",
         QoS.one);
     courierClient
-        .courierMessageStream(
-            "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update")
+        .courierMessageStream<TestData>(
+            "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            decoder: TestData.fromBytes)
         .listen((event) {
-      print("Message received: ${testDataDecoder(event)}");
+      print("Message received: ${event}");
+    });
+
+    courierClient
+        .courierMessageStream<Person>(
+            "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            decoder: Person.fromJson)
+        .listen((person) {
+      print("Message received: ${person.name}");
     });
   }
 
@@ -216,4 +225,12 @@ class MyHomePage extends StatelessWidget {
       ),
     );
   }
+}
+
+class Person {
+  String name;
+  Person({required this.name});
+
+  Person.fromJson(Map<String, dynamic> json) : name = json['name'];
+  Map<String, dynamic> toJson() => {'name': name};
 }

--- a/courier_dart_sdk_demo/lib/main.dart
+++ b/courier_dart_sdk_demo/lib/main.dart
@@ -6,9 +6,15 @@ import 'package:courier_dart_sdk/courier_client.dart';
 import 'package:courier_dart_sdk/config/courier_configuration.dart';
 import 'package:courier_dart_sdk/courier_connect_options.dart';
 import 'package:courier_dart_sdk/courier_message.dart';
+import 'package:courier_dart_sdk/message_adapter/bytes_message_adapter.dart';
+import 'package:courier_dart_sdk/message_adapter/json_message_adapter.dart';
+import 'package:courier_dart_sdk/message_adapter/string_message_adapter.dart';
+
+import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
 import 'package:courier_dart_sdk_demo/courier_response_mapper.dart';
 import 'package:courier_dart_sdk_demo/local_auth_provider.dart';
 import 'package:courier_dart_sdk_demo/test_data_type.dart';
+import 'package:courier_dart_sdk_demo/test_person_data.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
@@ -77,7 +83,12 @@ class MyHomePage extends StatelessWidget {
           authRetryPolicy: DefaultAuthRetryPolicy(),
           readTimeoutSeconds: 60,
           disconnectDelaySeconds: 10,
-          enableMQTTChuck: true));
+          enableMQTTChuck: true),
+      messageAdapters: const <MessageAdapter>[
+        JSONMessageAdapter(),
+        BytesMessageAdapter(),
+        StringMessageAdapter()
+      ]);
 
   String textMessage = "";
 
@@ -89,42 +100,54 @@ class MyHomePage extends StatelessWidget {
     courierClient.disconnect();
   }
 
-  TestData testDataDecoder(Uint8List bytes) => TestData.fromBytes(bytes);
-
   void _onSubscribe() {
     courierClient.subscribe(
         "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update", QoS.one);
     courierClient.subscribe(
         "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update/foreground",
         QoS.one);
+
     courierClient
         .courierMessageStream<TestData>(
             "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
             decoder: TestData.fromBytes)
         .listen((event) {
-      print("Message received: ${event}");
+      print("Message received testData: ${event.textMessage}");
     });
+
+    courierClient.subscribe(
+        "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update", QoS.one);
 
     courierClient
         .courierMessageStream<Person>(
-            "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
             decoder: Person.fromJson)
         .listen((person) {
-      print("Message received: ${person.name}");
+      print("Message received person: ${person.name}");
     });
   }
 
   void _onUnsubscribe() {
     courierClient
         .unsubscribe("orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update");
+
+    courierClient
+        .unsubscribe("person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update");
   }
 
-  Uint8List testDataEncoder(TestData testData) => testData.toBytes();
-
   void _onSend() {
+    final testData = TestData(textMessage);
+
+    courierClient.publishCourierMessage(
+        CourierMessage(
+            payload: testData,
+            topic: "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            qos: QoS.one),
+        encoder: (testData) => testData.toBytes());
+
     courierClient.publishCourierMessage(CourierMessage(
-        bytes: testDataEncoder(TestData(textMessage)),
-        topic: "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+        payload: Person(name: textMessage),
+        topic: "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
         qos: QoS.one));
   }
 
@@ -225,12 +248,4 @@ class MyHomePage extends StatelessWidget {
       ),
     );
   }
-}
-
-class Person {
-  String name;
-  Person({required this.name});
-
-  Person.fromJson(Map<String, dynamic> json) : name = json['name'];
-  Map<String, dynamic> toJson() => {'name': name};
 }

--- a/courier_dart_sdk_demo/lib/test_person_data.dart
+++ b/courier_dart_sdk_demo/lib/test_person_data.dart
@@ -1,0 +1,7 @@
+class Person {
+  String name;
+  Person({required this.name});
+
+  Person.fromJson(Map<String, dynamic> json) : name = json['name'];
+  Map<String, dynamic> toJson() => {'name': name};
+}

--- a/courier_dart_sdk_demo/pubspec.yaml
+++ b/courier_dart_sdk_demo/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
 environment:
-  sdk: '>=2.12.0'
+  sdk: '>=2.15.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
This MR provides the capability to pass MessageAdapter array to CourierClient. 

MessageAdapter provides an abstraction to encode model to bytes and decode bytes to object. We provide built-in  adapters such as:
1. JSONMessageAdapter -> Decode by using `constructor.fromJSON` passing Map<String, dynamic> and encode by invoking `instance.toJson()`. Uses `dart:convert` `jsonEncode` and `jsonDecode` under the hood.
2. BytesMessageAdapter
3. StringMessageAdapter. Uses `dart:convert` `utf8Encode` and `utf8Decode` under the hood.

You can pass this as an array when initializing CourierClient
```dart
final CourierClient courierClient = CourierClient.create(
     ....,
      messageAdapters: const <MessageAdapter>[
        JSONMessageAdapter(),
        BytesMessageAdapter(),
        StringMessageAdapter()
      ]);
```
Prioritization will be based on the order of the adapter in the list. When bytes is published/received, we will loop the adapters trying to encode/decode the data into specified type, the first one that is able to decode/encode, will be used.

* Example of Receiving data usage from Client side
```dart
/// This uses BytesMessageAdapter and used constructor tear-offs TestData.fromBytes
courierClient
    .courierMessageStream<TestData>(
        "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
        decoder: TestData.fromBytes)
    .listen((event) {
  print("Message received testData: ${event.textMessage}");
});

/// This uses JSONMessageAdapter and used constructor tear-offs Person.fromJson
courierClient
    .courierMessageStream<Person>(
        "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
        decoder: Person.fromJson)
    .listen((person) {
  print("Message received person: ${person.name}");
});
```

* Example of Publishing data  from Client side
```dart

/// This used JSONMessageAdapter which use dart jsonEncode to invoke toJson on object implicitly
courierClient.publishCourierMessage(CourierMessage(
    payload: Person(name: textMessage),
    topic: "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
    qos: QoS.one));


/// For this TestData without toJson method, you can provide your own encode to convert to Uint8List/bytes
courierClient.publishCourierMessage(
    CourierMessage(
        payload: testData,
        topic: "orders/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
        qos: QoS.one),
    encoder: (testData) => testData.toBytes());
```
