### PR TITLE
Add protobuf message adapter package

### DIFF
--- a/courier_dart_sdk_demo/lib/main.dart
+++ b/courier_dart_sdk_demo/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:courier_dart_sdk_demo/courier_response_mapper.dart';
 import 'package:courier_dart_sdk_demo/local_auth_provider.dart';
 import 'package:courier_dart_sdk_demo/test_data_type.dart';
 import 'package:courier_dart_sdk_demo/test_person_data.dart';
+import 'package:courier_dart_sdk_demo/test_pet.pb.dart';
+import 'package:courier_protobuf/protobuf_message_adapter.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
@@ -85,6 +87,7 @@ class MyHomePage extends StatelessWidget {
           disconnectDelaySeconds: 10,
           enableMQTTChuck: true),
       messageAdapters: const <MessageAdapter>[
+        ProtobufMessageAdapter(),
         JSONMessageAdapter(),
         BytesMessageAdapter(),
         StringMessageAdapter()
@@ -125,6 +128,17 @@ class MyHomePage extends StatelessWidget {
         .listen((person) {
       print("Message received person: ${person.name}");
     });
+
+    courierClient.subscribe(
+        "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update", QoS.one);
+
+    courierClient
+        .courierMessageStream<Pet>(
+            "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            decoder: Pet.fromBuffer)
+        .listen((pet) {
+      print("Message received Pet: ${pet.name}");
+    });
   }
 
   void _onUnsubscribe() {
@@ -133,6 +147,9 @@ class MyHomePage extends StatelessWidget {
 
     courierClient
         .unsubscribe("person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update");
+
+    courierClient
+        .unsubscribe("pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update");
   }
 
   void _onSend() {
@@ -148,6 +165,13 @@ class MyHomePage extends StatelessWidget {
     courierClient.publishCourierMessage(CourierMessage(
         payload: Person(name: textMessage),
         topic: "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+        qos: QoS.one));
+
+    final pet = Pet();
+    pet.name = "Hello Pet";
+    courierClient.publishCourierMessage(CourierMessage(
+        payload: pet,
+        topic: "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
         qos: QoS.one));
   }
 

--- a/courier_dart_sdk_demo/lib/test_pet.pb.dart
+++ b/courier_dart_sdk_demo/lib/test_pet.pb.dart
@@ -1,0 +1,60 @@
+//
+//  Generated code. Do not modify.
+//  source: test_pet.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class Pet extends $pb.GeneratedMessage {
+  factory Pet() => create();
+  Pet._() : super();
+  factory Pet.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Pet.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'Pet', package: const $pb.PackageName(_omitMessageNames ? '' : 'com.pet'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..hasRequiredFields = false
+  ;
+
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  Pet clone() => Pet()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Pet copyWith(void Function(Pet) updates) => super.copyWith((message) => updates(message as Pet)) as Pet;
+
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static Pet create() => Pet._();
+  Pet createEmptyInstance() => create();
+  static $pb.PbList<Pet> createRepeated() => $pb.PbList<Pet>();
+  @$core.pragma('dart2js:noInline')
+  static Pet getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Pet>(create);
+  static Pet? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+}
+
+
+const _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');
+const _omitMessageNames = $core.bool.fromEnvironment('protobuf.omit_message_names');

--- a/courier_dart_sdk_demo/lib/test_pet.pbjson.dart
+++ b/courier_dart_sdk_demo/lib/test_pet.pbjson.dart
@@ -1,0 +1,27 @@
+//
+//  Generated code. Do not modify.
+//  source: test_pet.proto
+//
+// @dart = 2.12
+
+// ignore_for_file: annotate_overrides, camel_case_types
+// ignore_for_file: constant_identifier_names, library_prefixes
+// ignore_for_file: non_constant_identifier_names, prefer_final_fields
+// ignore_for_file: unnecessary_import, unnecessary_this, unused_import
+
+import 'dart:convert' as $convert;
+import 'dart:core' as $core;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use petDescriptor instead')
+const Pet$json = {
+  '1': 'Pet',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `Pet`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List petDescriptor = $convert.base64Decode(
+    'CgNQZXQSEgoEbmFtZRgBIAEoCVIEbmFtZQ==');
+

--- a/courier_dart_sdk_demo/pubspec.lock
+++ b/courier_dart_sdk_demo/pubspec.lock
@@ -55,7 +55,14 @@ packages:
       path: "../courier_dart_sdk"
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.9"
+  courier_protobuf:
+    dependency: "direct main"
+    description:
+      path: "../courier_protobuf"
+      relative: true
+    source: path
+    version: "0.0.1"
   crypto:
     dependency: transitive
     description:
@@ -88,6 +95,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -210,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  protobuf:
+    dependency: transitive
+    description:
+      name: protobuf
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/courier_dart_sdk_demo/pubspec.yaml
+++ b/courier_dart_sdk_demo/pubspec.yaml
@@ -36,7 +36,8 @@ dependencies:
 
   courier_dart_sdk:
     path: ../courier_dart_sdk
-
+  courier_protobuf:
+    path: ../courier_protobuf
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/courier_dart_sdk_demo/test_pet.proto
+++ b/courier_dart_sdk_demo/test_pet.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package com.pet;
+
+message Pet {
+    string name = 1;
+}

--- a/courier_protobuf/.gitignore
+++ b/courier_protobuf/.gitignore
@@ -1,0 +1,30 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.packages
+build/

--- a/courier_protobuf/.metadata
+++ b/courier_protobuf/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: f468f3366c26a5092eb964a230ce7892fda8f2f8
+  channel: stable
+
+project_type: package

--- a/courier_protobuf/CHANGELOG.md
+++ b/courier_protobuf/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* Initial Release of ProtobufMessageAdapter

--- a/courier_protobuf/LICENSE
+++ b/courier_protobuf/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/courier_protobuf/README.md
+++ b/courier_protobuf/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/courier_protobuf/analysis_options.yaml
+++ b/courier_protobuf/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/courier_protobuf/lib/protobuf_message_adapter.dart
+++ b/courier_protobuf/lib/protobuf_message_adapter.dart
@@ -1,0 +1,23 @@
+import 'dart:typed_data';
+
+import 'package:courier_dart_sdk/message_adapter/message_adapter.dart';
+import 'package:protobuf/protobuf.dart';
+
+class ProtobufMessageAdapter extends MessageAdapter {
+  const ProtobufMessageAdapter();
+
+  @override
+  String contentType() => "application/x-protobuf";
+
+  @override
+  T decode<T>(Uint8List bytes, dynamic decoder) => decoder(bytes);
+
+  @override
+  Uint8List encode(Object object, String topic, dynamic encoder) {
+    if (object is GeneratedMessage) {
+      return object.writeToBuffer();
+    }
+    throw Exception(
+        '${object.runtimeType} is not of type protobuf generated message');
+  }
+}

--- a/courier_protobuf/pubspec.yaml
+++ b/courier_protobuf/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  courier_dart_sdk: 0.0.9
+  courier_dart_sdk:
+    path: ../courier_dart_sdk
   protobuf: ^2.0.1
 
 dev_dependencies:

--- a/courier_protobuf/pubspec.yaml
+++ b/courier_protobuf/pubspec.yaml
@@ -1,0 +1,21 @@
+name: courier_protobuf
+description: A new Flutter package project.
+version: 0.0.1
+homepage:
+
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=1.17.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  courier_dart_sdk: 0.0.9
+  protobuf: ^2.0.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:


### PR DESCRIPTION
This MR adds a package containing `ProtobufMessageAdapter` which depends on Google Dart `Protobuf` package. You can use this to listen to Protobuf based GeneratedMessage type courier stream and publish generated message as bytes.

Simply pass this to message adapters list when initializing `CourierClient` like so
```dart
final CourierClient courierClient = CourierClient.create(
      ....,
      messageAdapters: const <MessageAdapter>[
        ProtobufMessageAdapter(),
        JSONMessageAdapter(),
        BytesMessageAdapter(),
        StringMessageAdapter()
      ]);
```

Decode bytes to Pet.pb GeneratedMessage:
```dart
courierClient
        .courierMessageStream<Pet>(
            "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
            decoder: Pet.fromBuffer)
        .listen((pet) {
      print("Message received Pet: ${pet.name}");
    });
```

Encode Pet GeneratedMessage pb to bytes:
```dart
final pet = Pet();
    pet.name = "Hello Pet";
    courierClient.publishCourierMessage(CourierMessage(
        payload: pet,
        topic: "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
        qos: QoS.one));
```
