### PR TITLE
Add ability to pass optional message adapter for receiving/publishing

### DIFF
--- a/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/json_message_adapter.dart
@@ -18,9 +18,6 @@ class JSONMessageAdapter extends MessageAdapter {
 
   @override
   Uint8List encode(Object object, String topic, dynamic encoder) {
-    if (encoder != null) {
-      return encoder(object);
-    }
     final json = jsonEncode(object);
     final List<int> codeUnits = json.codeUnits;
     final Uint8List bytes = Uint8List.fromList(codeUnits);

--- a/courier_dart_sdk/lib/message_adapter/string_message_adapter.dart
+++ b/courier_dart_sdk/lib/message_adapter/string_message_adapter.dart
@@ -17,10 +17,7 @@ class StringMessageAdapter extends MessageAdapter {
 
   @override
   Uint8List encode(Object object, String topic, dynamic encoder) {
-    if (object is String) {
-      List<int> bytes = utf8.encode(object);
-      return Uint8List.fromList(bytes);
-    }
-    return encoder(object);
+    List<int> bytes = utf8.encode(object as String);
+    return Uint8List.fromList(bytes);
   }
 }

--- a/courier_dart_sdk_demo/lib/main.dart
+++ b/courier_dart_sdk_demo/lib/main.dart
@@ -130,6 +130,15 @@ class MyHomePage extends StatelessWidget {
       log("Message received person: ${person.name}");
     });
 
+    courierClient
+        .courierMessageStream<Person>(
+            "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            adapter: const JSONMessageAdapter(),
+            decoder: Person.fromJson)
+        .listen((person) {
+      log("Message received person using explicit JSON Adapter: ${person.name}");
+    });
+
     courierClient.subscribe(
         "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update", QoS.one);
 
@@ -139,6 +148,14 @@ class MyHomePage extends StatelessWidget {
             decoder: Pet.fromBuffer)
         .listen((pet) {
       log("Message received Pet: ${pet.name}");
+    });
+
+    courierClient
+        .courierMessageStream<Uint8List>(
+            "pet/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            adapter: const BytesMessageAdapter())
+        .listen((petBytes) {
+      log("Message received PetBytes using explicit bytes message adapter: ${petBytes.toString()}");
     });
 
     courierClient
@@ -175,6 +192,15 @@ class MyHomePage extends StatelessWidget {
         payload: Person(name: textMessage),
         topic: "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
         qos: QoS.one));
+
+    courierClient.publishCourierMessage(
+        CourierMessage(
+            payload: Person(
+                name:
+                    textMessage + "explicit encoding with JSONMessageAdapter"),
+            topic: "person/6b57d4e5-0fce-4917-b343-c8a1c77405e5/update",
+            qos: QoS.one),
+        adapter: const JSONMessageAdapter());
 
     final pet = Pet();
     pet.name = "Hello Pet";


### PR DESCRIPTION
This MR provides:
Add optional MessageAdapter for `messageStream` and `publish` If this is passed, it will use it to decode/encode the data, otherwise it will use the messageAdapters passed when initializing `CourierClient`