### PR TITLE
Add onAuthFailure method for AuthProvider

### DIFF
--- a/courier_dart_sdk/lib/auth/auth_provider.dart
+++ b/courier_dart_sdk/lib/auth/auth_provider.dart
@@ -2,4 +2,5 @@ import 'package:courier_dart_sdk/courier_connect_options.dart';
 
 abstract class AuthProvider {
   Future<CourierConnectOptions> fetchConnectOptions();
+  void onAuthFailure();
 }

--- a/courier_dart_sdk/lib/auth/auth_provider.dart
+++ b/courier_dart_sdk/lib/auth/auth_provider.dart
@@ -2,5 +2,5 @@ import 'package:courier_dart_sdk/courier_connect_options.dart';
 
 abstract class AuthProvider {
   Future<CourierConnectOptions> fetchConnectOptions();
-  void onAuthFailure();
+  Future<void> onAuthFailure();
 }

--- a/courier_dart_sdk/lib/auth/dio_auth_provider.dart
+++ b/courier_dart_sdk/lib/auth/dio_auth_provider.dart
@@ -31,5 +31,5 @@ class DioAuthProvider implements AuthProvider {
   }
 
   @override
-  void onAuthFailure() {}
+  Future<void> onAuthFailure() async {}
 }

--- a/courier_dart_sdk/lib/auth/dio_auth_provider.dart
+++ b/courier_dart_sdk/lib/auth/dio_auth_provider.dart
@@ -29,4 +29,7 @@ class DioAuthProvider implements AuthProvider {
           type: DioExceptionType.connectionError);
     }
   }
+
+  @override
+  void onAuthFailure() {}
 }

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -265,7 +265,7 @@ class _CourierClientImpl implements CourierClient {
   Future<dynamic> _callbackHandler(MethodCall methodCall) async {
     switch (methodCall.method) {
       case 'onAuthFailure':
-        _handleAuthFailure();
+        await _handleAuthFailure();
         return;
       case 'onMessageReceive':
         _handleMessage(methodCall.arguments);
@@ -278,8 +278,8 @@ class _CourierClientImpl implements CourierClient {
     }
   }
 
-  void _handleAuthFailure() {
-    authProvider.onAuthFailure();
+  Future<void> _handleAuthFailure() async {
+    await authProvider.onAuthFailure();
     connect();
   }
 

--- a/courier_dart_sdk/lib/courier_client.dart
+++ b/courier_dart_sdk/lib/courier_client.dart
@@ -279,6 +279,7 @@ class _CourierClientImpl implements CourierClient {
   }
 
   void _handleAuthFailure() {
+    authProvider.onAuthFailure();
     connect();
   }
 

--- a/courier_dart_sdk_demo/lib/local_auth_provider.dart
+++ b/courier_dart_sdk_demo/lib/local_auth_provider.dart
@@ -10,4 +10,7 @@ class LocalAuthProvider implements AuthProvider {
   Future<CourierConnectOptions> fetchConnectOptions() {
     return Future<CourierConnectOptions>.value(connectOptions);
   }
+
+  @override
+  void onAuthFailure() {}
 }

--- a/courier_dart_sdk_demo/lib/local_auth_provider.dart
+++ b/courier_dart_sdk_demo/lib/local_auth_provider.dart
@@ -12,5 +12,5 @@ class LocalAuthProvider implements AuthProvider {
   }
 
   @override
-  void onAuthFailure() {}
+  Future<void> onAuthFailure() async {}
 }


### PR DESCRIPTION
This provides signal to `AuthProvider` that Broker has responded with Authentication Failure when connecting. For example, this can be used to clear cache in AuthProvider Concrete implementation.