### PR TITLE
fix: Revert the move to background in CourierDartSdkPlugin 

### DIFF
--- a/courier_dart_sdk/CHANGELOG.md
+++ b/courier_dart_sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+* Revert the CourierDartSdkPlugin changes on by v0.1.0 changes due to issues multiple registrations
+
 ## 0.1.1
 * Update iOS podspec to remove version pins on CourierCore, CourierMQTT, CourierMQTTChuck and bump minimum iOS platform to 15.0
 

--- a/courier_dart_sdk/android/src/main/kotlin/com/gojek/courier/courier_dart_sdk/CourierDartSdkPlugin.kt
+++ b/courier_dart_sdk/android/src/main/kotlin/com/gojek/courier/courier_dart_sdk/CourierDartSdkPlugin.kt
@@ -26,313 +26,243 @@ import com.gojek.mqtt.model.ServerUri
 import com.gojek.mqtt.policies.connecttimeout.ConnectTimeoutConfig
 import com.gojek.mqtt.policies.connecttimeout.ConnectTimeoutPolicy
 import com.gojek.timer.pingsender.TimerPingSenderFactory
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 /** CourierDartSdkPlugin */
-class CourierDartSdkPlugin : FlutterPlugin, MethodCallHandler {
-    /// The MethodChannel that will the communication between Flutter and native Android
-    ///
-    /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-    /// when the Flutter Engine is detached from the Activity
-    private lateinit var context: Context
-    private lateinit var mqttConfiguration: MqttV3Configuration
-    private lateinit var mqttClientDelegate: MqttClientDelegate
-    private lateinit var methodChannel: MethodChannel
-    private val handler = Handler(Looper.getMainLooper())
-    private var readTimeoutSeconds: Int = 0
-    private var disconnectDelaySeconds: Int = 0
-    private val mainThreadHandler = Handler(Looper.getMainLooper())
+class CourierDartSdkPlugin: FlutterPlugin, MethodCallHandler {
+  /// The MethodChannel that will the communication between Flutter and native Android
+  ///
+  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
+  /// when the Flutter Engine is detached from the Activity
+  private lateinit var context: Context
+  private lateinit var mqttConfiguration: MqttV3Configuration
+  private lateinit var mqttClientDelegate: MqttClientDelegate
+  private lateinit var methodChannel: MethodChannel
+  private val handler = Handler(Looper.getMainLooper())
+  private var readTimeoutSeconds: Int = 0
+  private var disconnectDelaySeconds: Int = 0
+  private val mainThreadHandler = Handler(Looper.getMainLooper())
 
-    private val disconnectRunnable = Runnable {
-        mqttClientDelegate.disconnect(false)
+  private val disconnectRunnable = Runnable {
+    mqttClientDelegate.disconnect(false)
+  }
+
+  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "courier")
+    methodChannel.setMethodCallHandler(this)
+
+    this.context = flutterPluginBinding.applicationContext
+  }
+
+  override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
+    if (call.method == "initialise") {
+      initialise(call.arguments() as Map<String, Any>?)
+      result.success("initialised")
+    } else if (call.method == "connect") {
+      connect(call.arguments() as Map<String, Any>?)
+      result.success("connected")
+    } else if (call.method == "disconnect") {
+      disconnect(call.arguments() as Map<String, Any>?)
+      result.success("disconnected")
+    } else if (call.method == "subscribe") {
+      subscribe(call.arguments() as Map<String, Any>?)
+      result.success("subscribed")
+    } else if (call.method == "unsubscribe") {
+      unsubscribe(call.arguments() as Map<String, Any>?)
+      result.success("unsubscribed")
+    } else if (call.method == "send") {
+      send(call.arguments() as Map<String, Any>?)
+      result.success("sent")
+    } else {
+      result.notImplemented()
+    }
+  }
+
+  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    methodChannel.setMethodCallHandler(null)
+  }
+
+  private fun initialise(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while initialising the sdk")
+    }
+    val activityCheckIntervalSeconds = arguments["activityCheckIntervalSeconds"]!! as Int
+    val inactivityTimeoutSeconds = arguments["inactivityTimeoutSeconds"]!! as Int
+    val pingSender = if (arguments["timerPingSenderEnabled"]!! as Boolean) {
+      TimerPingSenderFactory.create()
+    } else {
+      AlarmPingSenderFactory.createMqttPingSender(context, AlarmPingSenderConfig())
+    }
+    val connectRetryPolicyConfig = arguments["connectRetryPolicyConfig"]!! as Map<String, Any>
+    val connectTimeoutPolicyConfig = arguments["connectTimeoutConfig"]!! as Map<String, Any>
+
+    val enableMqttChuck = if (arguments["enableMQTTChuck"] is Boolean) {
+        arguments["enableMQTTChuck"]!! as Boolean
+    } else {
+        false
     }
 
-    private val executor = Executors.newSingleThreadExecutor()
+    readTimeoutSeconds = arguments["readTimeoutSeconds"]!! as Int
+    disconnectDelaySeconds = arguments["disconnectDelaySeconds"]!! as Int
 
-    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "courier")
-        methodChannel.setMethodCallHandler(this)
+    mqttConfiguration = MqttV3Configuration(
+        connectTimeoutPolicy = ConnectTimeoutPolicy(ConnectTimeoutConfig(
+            sslUpperBoundConnTimeOut = connectTimeoutPolicyConfig["socketTimeout"] as Int,
+            sslHandshakeTimeOut = connectTimeoutPolicyConfig["handshakeTimeout"] as Int,
+        )),
+        connectRetryTimePolicy = ConnectRetryPolicy(
+            baseTimeSecs = connectRetryPolicyConfig["baseRetryTimeSeconds"] as Int,
+            maxTimeSecs = connectRetryPolicyConfig["maxRetryTimeSeconds"] as Int,
+        ),
+        authenticator = object : Authenticator {
+          override fun authenticate(connectOptions: MqttConnectOptions, forceRefresh: Boolean): MqttConnectOptions {
+            return connectOptions
+          }
+        },
+        experimentConfigs = ExperimentConfigs(
+            activityCheckIntervalSeconds = activityCheckIntervalSeconds,
+            inactivityTimeoutSeconds = inactivityTimeoutSeconds,
+        ),
+        pingSender = pingSender,
+        mqttInterceptorList = if (enableMqttChuck) listOf(MqttChuckInterceptor(context, MqttChuckConfig())) else emptyList(),
+        eventHandler = MqttEventHandler(::handleEvent),
+        authFailureHandler = object : AuthFailureHandler {
+          override fun handleAuthFailure() {
+            handleAuthFailureInternal()
+          }
+        }
+    )
+    mqttClientDelegate = MqttClientDelegate(context, mqttConfiguration)
+    mqttClientDelegate.receive(object : MessageListener {
+      override fun onMessageReceived(mqttMessage: MqttMessage) {
+        handleMqttMessageReceive(mqttMessage)
+      }
+    })
+  }
 
-        this.context = flutterPluginBinding.applicationContext
+  private fun connect(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while connecting")
     }
+    mainThreadHandler.removeCallbacks(disconnectRunnable)
+    val mqttConnectOptions = MqttConnectOptions(
+        clientId = arguments["clientId"]!! as String,
+        username = arguments["username"]!! as String,
+        password = arguments["password"]!! as String,
+        serverUris = listOf(ServerUri(arguments["host"]!! as String, arguments["port"] as Int, arguments["scheme"]!! as String)),
+        keepAlive = KeepAlive(arguments["keepAliveSeconds"] as Int),
+        isCleanSession = arguments["cleanSession"]!! as Boolean,
+        readTimeoutSecs = readTimeoutSeconds
+    )
+    mqttClientDelegate.connect(mqttConnectOptions)
+  }
 
-    override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
-        when (call.method) {
-            "initialise" -> executeAsync(result) {
-                initialise(call.arguments() as Map<String, Any>?)
-                "initialised"
-            }
-
-            "connect" -> executeAsync(result) {
-                connect(call.arguments() as Map<String, Any>?)
-                "connected"
-            }
-
-            "disconnect" -> executeAsync(result) {
-                disconnect(call.arguments() as Map<String, Any>?)
-                "disconnected"
-            }
-
-            "subscribe" -> executeAsync(result) {
-                subscribe(call.arguments() as Map<String, Any>?)
-                "subscribed"
-            }
-
-            "unsubscribe" -> executeAsync(result) {
-                unsubscribe(call.arguments() as Map<String, Any>?)
-                "unsubscribed"
-            }
-
-            "send" -> executeAsync(result) {
-                send(call.arguments() as Map<String, Any>?)
-                "sent"
-            }
-
-            else -> result.notImplemented()
-        }
+  private fun disconnect(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while disconnecting")
     }
-
-    private fun executeAsync(result: Result, block: () -> String) {
-        executor.execute {
-            try {
-                Log.d(
-                    TAG,
-                    "Executing async block on thread: ${Thread.currentThread().name}"
-                )
-                val response = block()
-                handler.post { result.success(response) }
-            } catch (e: Exception) {
-                handler.post {
-                    result.error("ERROR", e.message, e.stackTraceToString())
-                }
-            }
-        }
+    val clearState = arguments["clearState"]!! as Boolean
+    if (disconnectDelaySeconds > 0 && clearState.not()) {
+      mainThreadHandler.postDelayed(
+        disconnectRunnable,
+        TimeUnit.SECONDS.toMillis(disconnectDelaySeconds.toLong())
+      )
+    } else {
+      mqttClientDelegate.disconnect(clearState)
     }
+  }
 
-    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-        methodChannel.setMethodCallHandler(null)
-        executor.shutdown()
+  private fun subscribe(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while subscribing")
     }
+    val qos = arguments["qos"]!! as Int
+    val topic = arguments["topic"]!! as String
+    mqttClientDelegate.subscribe(topic, qos.toQoS())
+  }
 
-    private fun initialise(arguments: Map<String, Any>?) {
-        Log.d(TAG, "Initialising Courier Dart SDK")
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while initialising the sdk")
+  private fun unsubscribe(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while unsubscribing")
+    }
+    val topic = arguments["topic"]!! as String
+    mqttClientDelegate.unsubscribe(topic)
+  }
+
+  private fun send(arguments: Map<String, Any>?) {
+    if (arguments.isNullOrEmpty()) {
+      throw IllegalArgumentException("Arguments must be present while sending a message")
+    }
+    val message = arguments["message"]!! as ByteArray
+    val qos = arguments["qos"]!! as Int
+    val topic = arguments["topic"]!! as String
+    mqttClientDelegate.send(message, qos.toQoS(), topic)
+  }
+
+  private fun handleAuthFailureInternal() {
+    handler.post {
+      methodChannel.invokeMethod("onAuthFailure", null, object : MethodChannel.Result {
+        override fun success(result: Any?) {
+          Log.d("Courier", "onAuthFailure invocation success: $result")
         }
-        val activityCheckIntervalSeconds = arguments["activityCheckIntervalSeconds"]!! as Int
-        val inactivityTimeoutSeconds = arguments["inactivityTimeoutSeconds"]!! as Int
-        val pingSender = if (arguments["timerPingSenderEnabled"]!! as Boolean) {
-            TimerPingSenderFactory.create()
-        } else {
-            AlarmPingSenderFactory.createMqttPingSender(context, AlarmPingSenderConfig())
-        }
-        val connectRetryPolicyConfig = arguments["connectRetryPolicyConfig"]!! as Map<String, Any>
-        val connectTimeoutPolicyConfig = arguments["connectTimeoutConfig"]!! as Map<String, Any>
 
-        val enableMqttChuck = if (arguments["enableMQTTChuck"] is Boolean) {
-            arguments["enableMQTTChuck"]!! as Boolean
-        } else {
-            false
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+          Log.d("Courier", "onAuthFailure invocation error: $errorMessage")
         }
 
-        readTimeoutSeconds = arguments["readTimeoutSeconds"]!! as Int
-        disconnectDelaySeconds = arguments["disconnectDelaySeconds"]!! as Int
+        override fun notImplemented() {
+          Log.d("Courier", "onAuthFailure invocation notImplemented")
+        }
 
-        mqttConfiguration = MqttV3Configuration(
-            connectTimeoutPolicy = ConnectTimeoutPolicy(
-                ConnectTimeoutConfig(
-                    sslUpperBoundConnTimeOut = connectTimeoutPolicyConfig["socketTimeout"] as Int,
-                    sslHandshakeTimeOut = connectTimeoutPolicyConfig["handshakeTimeout"] as Int,
-                )
-            ),
-            connectRetryTimePolicy = ConnectRetryPolicy(
-                baseTimeSecs = connectRetryPolicyConfig["baseRetryTimeSeconds"] as Int,
-                maxTimeSecs = connectRetryPolicyConfig["maxRetryTimeSeconds"] as Int,
-            ),
-            authenticator = object : Authenticator {
-                override fun authenticate(
-                    connectOptions: MqttConnectOptions,
-                    forceRefresh: Boolean
-                ): MqttConnectOptions {
-                    return connectOptions
-                }
-            },
-            experimentConfigs = ExperimentConfigs(
-                activityCheckIntervalSeconds = activityCheckIntervalSeconds,
-                inactivityTimeoutSeconds = inactivityTimeoutSeconds,
-            ),
-            pingSender = pingSender,
-            mqttInterceptorList = if (enableMqttChuck) listOf(
-                MqttChuckInterceptor(
-                    context,
-                    MqttChuckConfig()
-                )
-            ) else emptyList(),
-            eventHandler = MqttEventHandler(::handleEvent),
-            authFailureHandler = object : AuthFailureHandler {
-                override fun handleAuthFailure() {
-                    handleAuthFailureInternal()
-                }
-            }
-        )
-        mqttClientDelegate = MqttClientDelegate(context, mqttConfiguration)
-        mqttClientDelegate.receive(object : MessageListener {
-            override fun onMessageReceived(mqttMessage: MqttMessage) {
-                handleMqttMessageReceive(mqttMessage)
-            }
+      })
+    }
+  }
+
+  private fun handleMqttMessageReceive(mqttMessage: MqttMessage) {
+    val arguments = mutableMapOf<String, Any>()
+    arguments["message"] = (mqttMessage.message as Message.Bytes).value
+    arguments["topic"] = mqttMessage.topic
+
+    handler.post {
+      methodChannel.invokeMethod("onMessageReceive", arguments, object : MethodChannel.Result {
+        override fun success(result: Any?) {
+          Log.d("Courier", "onMessageReceive invocation success: $result")
+        }
+
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+          Log.d("Courier", "onMessageReceive invocation error: $errorMessage")
+        }
+
+        override fun notImplemented() {
+          Log.d("Courier", "onMessageReceive invocation notImplemented")
+        }
+      })
+    }
+  }
+
+  private fun handleEvent(eventMap: Map<String, Any>) {
+    if (eventMap.isNotEmpty()) {
+      handler.post {
+        methodChannel.invokeMethod("handleEvent", eventMap, object : MethodChannel.Result {
+          override fun success(result: Any?) {
+            Log.d("Courier", "handleEvent invocation success: $result")
+          }
+
+          override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+            Log.d("Courier", "handleEvent invocation error: $errorMessage")
+          }
+
+          override fun notImplemented() {
+            Log.d("Courier", "handleEvent invocation notImplemented")
+          }
         })
+      }
     }
-
-    private fun connect(arguments: Map<String, Any>?) {
-        Log.d(TAG, "Connecting Courier Dart SDK")
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while connecting")
-        }
-        mainThreadHandler.removeCallbacks(disconnectRunnable)
-        val mqttConnectOptions = MqttConnectOptions(
-            clientId = arguments["clientId"]!! as String,
-            username = arguments["username"]!! as String,
-            password = arguments["password"]!! as String,
-            serverUris = listOf(
-                ServerUri(
-                    arguments["host"]!! as String,
-                    arguments["port"] as Int,
-                    arguments["scheme"]!! as String
-                )
-            ),
-            keepAlive = KeepAlive(arguments["keepAliveSeconds"] as Int),
-            isCleanSession = arguments["cleanSession"]!! as Boolean,
-            readTimeoutSecs = readTimeoutSeconds
-        )
-        mqttClientDelegate.connect(mqttConnectOptions)
-    }
-
-    private fun disconnect(arguments: Map<String, Any>?) {
-        Log.d(TAG, "Disconnecting Courier Dart SDK")
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while disconnecting")
-        }
-        val clearState = arguments["clearState"]!! as Boolean
-        if (disconnectDelaySeconds > 0 && clearState.not()) {
-            mainThreadHandler.postDelayed(
-                disconnectRunnable,
-                TimeUnit.SECONDS.toMillis(disconnectDelaySeconds.toLong())
-            )
-        } else {
-            mqttClientDelegate.disconnect(clearState)
-        }
-    }
-
-    private fun subscribe(arguments: Map<String, Any>?) {
-
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while subscribing")
-        }
-        val qos = arguments["qos"]!! as Int
-        val topic = arguments["topic"]!! as String
-        Log.d(TAG, "Subscribing Courier Dart SDK to topic: $topic with QoS: $qos")
-        mqttClientDelegate.subscribe(topic, qos.toQoS())
-    }
-
-    private fun unsubscribe(arguments: Map<String, Any>?) {
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while unsubscribing")
-        }
-        val topic = arguments["topic"]!! as String
-        Log.d(TAG, "Unsubscribing Courier Dart SDK from topic: $topic")
-        mqttClientDelegate.unsubscribe(topic)
-    }
-
-    private fun send(arguments: Map<String, Any>?) {
-        if (arguments.isNullOrEmpty()) {
-            throw IllegalArgumentException("Arguments must be present while sending a message")
-        }
-        val message = arguments["message"]!! as ByteArray
-        val qos = arguments["qos"]!! as Int
-        val topic = arguments["topic"]!! as String
-        Log.d(TAG, "Sending message to topic: $topic with QoS: $qos")
-        mqttClientDelegate.send(message, qos.toQoS(), topic)
-    }
-
-    private fun handleAuthFailureInternal() {
-        handler.post {
-            methodChannel.invokeMethod("onAuthFailure", null, object : MethodChannel.Result {
-                override fun success(result: Any?) {
-                    Log.d("Courier", "onAuthFailure invocation success: $result")
-                }
-
-                override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
-                    Log.d("Courier", "onAuthFailure invocation error: $errorMessage")
-                }
-
-                override fun notImplemented() {
-                    Log.d("Courier", "onAuthFailure invocation notImplemented")
-                }
-
-            })
-        }
-    }
-
-    private fun handleMqttMessageReceive(mqttMessage: MqttMessage) {
-        val arguments = mutableMapOf<String, Any>()
-        arguments["message"] = (mqttMessage.message as Message.Bytes).value
-        arguments["topic"] = mqttMessage.topic
-
-        handler.post {
-            methodChannel.invokeMethod(
-                "onMessageReceive",
-                arguments,
-                object : MethodChannel.Result {
-                    override fun success(result: Any?) {
-                        Log.d("Courier", "onMessageReceive invocation success: $result")
-                    }
-
-                    override fun error(
-                        errorCode: String,
-                        errorMessage: String?,
-                        errorDetails: Any?
-                    ) {
-                        Log.d("Courier", "onMessageReceive invocation error: $errorMessage")
-                    }
-
-                    override fun notImplemented() {
-                        Log.d("Courier", "onMessageReceive invocation notImplemented")
-                    }
-                })
-        }
-    }
-
-    private fun handleEvent(eventMap: Map<String, Any>) {
-        if (eventMap.isNotEmpty()) {
-            handler.post {
-                methodChannel.invokeMethod("handleEvent", eventMap, object : MethodChannel.Result {
-                    override fun success(result: Any?) {
-                        Log.d("Courier", "handleEvent invocation success: $result")
-                    }
-
-                    override fun error(
-                        errorCode: String,
-                        errorMessage: String?,
-                        errorDetails: Any?
-                    ) {
-                        Log.d("Courier", "handleEvent invocation error: $errorMessage")
-                    }
-
-                    override fun notImplemented() {
-                        Log.d("Courier", "handleEvent invocation notImplemented")
-                    }
-                })
-            }
-        }
-    }
-
-    companion object {
-        const val TAG = "CourierDartSdkPlugin"
-    }
+  }
 }

--- a/courier_dart_sdk/ios/courier_dart_sdk.podspec
+++ b/courier_dart_sdk/ios/courier_dart_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'courier_dart_sdk'
-  s.version          = '0.1.0'
+  s.version          = '0.1.2'
   s.summary          = 'Flutter SDK for Courier'
   s.description      = <<-DESC
 Flutter SDK for Courier

--- a/courier_dart_sdk/pubspec.yaml
+++ b/courier_dart_sdk/pubspec.yaml
@@ -1,7 +1,7 @@
 name: courier_dart_sdk
 description: Flutter SDK for Courier
-version: 0.1.1
-homepage: GitHub - gojek/courier-flutter: Dart port of our popular courier library
+version: 0.1.2
+homepage: https://github.com/gojek/courier-flutter
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/courier_dart_sdk_demo/pubspec.lock
+++ b/courier_dart_sdk_demo/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: "../courier_dart_sdk"
       relative: true
     source: path
-    version: "0.0.18"
+    version: "0.1.2"
   courier_protobuf:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Description
After https://github.com/gojek/courier-flutter/pull/22 we found that there is an edge cases where a single user able to fires thousand registration request to racoon. As we fixed the ANR of the client app, we revert this change to avoid server computation increases.